### PR TITLE
Adding basic login mutation implementation with error handling

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -4,8 +4,8 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "vite",
-    "build": "tsc && vite build",
+    "dev": "yarn run relay && vite",
+    "build": "yarn run relay && tsc && vite build",
     "preview": "vite preview",
     "relay": "yarn run relay-compiler"
   },
@@ -14,10 +14,13 @@
     "@emotion/styled": "^11.10.4",
     "@mui/icons-material": "^5.10.3",
     "@mui/material": "^5.10.5",
+    "formik": "^2.2.9",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-relay": "^14.1.0",
-    "relay-runtime": "^14.1.0"
+    "react-router-dom": "^6.4.0",
+    "relay-runtime": "^14.1.0",
+    "yup": "^0.32.11"
   },
   "devDependencies": {
     "@types/react": "^18.0.17",
@@ -36,7 +39,11 @@
     "src": "./src/",
     "schema": "./schema.graphql",
     "language": "typescript",
-    "eagerEsModules":true,
-    "exclude": ["**/node_modules/**", "**/__mocks__/**", "**/__generated__/**"]
+    "eagerEsModules": true,
+    "exclude": [
+      "**/node_modules/**",
+      "**/__mocks__/**",
+      "**/__generated__/**"
+    ]
   }
 }

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -1,56 +1,16 @@
-import ProductCard from "./components/ProductCard"
-import Topbar from "./components/Topbar"
-import {graphql, loadQuery, usePreloadedQuery} from 'react-relay'
-import relayEnvironment from "./relay/relayEnvironment";
-
-
-  const AllProductsQuery = graphql`
-    query AppGetAllProductsQuery {
-      products {
-        count
-        edges {
-          node {
-            description
-            name
-            _id
-            reviews {
-              edges {
-                node {
-                  comment
-                  rating
-                  user {
-                    email
-                    name
-                  }
-                }
-              }
-            }
-            user {
-              name
-              email
-            }
-          }
-        }
-      }
-    }
-  `;
-
-  const preloadedQuery = loadQuery(relayEnvironment, AllProductsQuery, {});
+import Topbar from './components/Topbar';
+import { Routes } from './Routes';
+import { BrowserRouter } from 'react-router-dom';
 
 function App() {
-
-  const data = usePreloadedQuery(AllProductsQuery, preloadedQuery)
-
-
   return (
     <div>
-      <Topbar / >
-      <ProductCard />
-      <pre>
-        {JSON.stringify(data, null, 4)}
-      </pre>
+      <Topbar />
+      <BrowserRouter>
+        <Routes />
+      </BrowserRouter>
     </div>
-  )
+  );
 }
 
-export default App
+export default App;

--- a/packages/web/src/Routes.tsx
+++ b/packages/web/src/Routes.tsx
@@ -1,0 +1,9 @@
+import { Routes as Router, Route } from 'react-router-dom';
+
+import { AuthRoutes } from './modules/auth/AuthRoutes';
+
+export const Routes = () => (
+  <Router>
+    <Route path="/*" element={<AuthRoutes />} />
+  </Router>
+);

--- a/packages/web/src/components/InputField.tsx
+++ b/packages/web/src/components/InputField.tsx
@@ -1,0 +1,34 @@
+import {
+  FormControl,
+  OutlinedInput as MyInput,
+  InputProps,
+} from '@mui/material';
+import { ErrorMessage, useField } from 'formik';
+
+type Props = InputProps & {
+  name: string;
+  shouldValidate?: boolean;
+};
+
+export const InputField = ({
+  name,
+  shouldValidate = false,
+  ...rest
+}: Props) => {
+  const [field, meta] = useField(name);
+
+  const hasAnErrorAndHasBeenTouched = !!meta.error && meta.touched;
+
+  const propsWhenShouldValidateProps = {
+    isInvalid: hasAnErrorAndHasBeenTouched,
+  };
+
+  return (
+    <FormControl {...(shouldValidate ? propsWhenShouldValidateProps : {})}>
+      <MyInput {...field} {...rest} />
+      {shouldValidate && (
+        <ErrorMessage name={name}>{error => error}</ErrorMessage>
+      )}
+    </FormControl>
+  );
+};

--- a/packages/web/src/components/ProductCard.tsx
+++ b/packages/web/src/components/ProductCard.tsx
@@ -17,7 +17,7 @@ interface ExpandMoreProps extends IconButtonProps {
 
 export default function ProductCard() {
   return (
-    <Card sx={{ maxWidth: 345 }}>
+    <Card elevation={12} sx={{ maxWidth: 345 }}>
       <CardHeader
         avatar={
           <Avatar sx={{ bgcolor: red[500] }} aria-label="recipe">
@@ -44,8 +44,8 @@ export default function ProductCard() {
         </Typography>
       </CardContent>
       <CardActions disableSpacing>
-        <IconButton style={{flexGrow: 1}} aria-label="reviews">
-          Reviews 
+        <IconButton style={{ flexGrow: 1 }} aria-label="reviews">
+          Reviews
           <ArrowForwardIcon />
         </IconButton>
       </CardActions>

--- a/packages/web/src/components/Topbar.tsx
+++ b/packages/web/src/components/Topbar.tsx
@@ -12,13 +12,18 @@ import Tooltip from '@mui/material/Tooltip';
 import MenuItem from '@mui/material/MenuItem';
 import AdbIcon from '@mui/icons-material/Adb';
 import PersonIcon from '@mui/icons-material/Person';
+import { Reviews } from '@mui/icons-material';
 
-const pages = ['Home','Post a product', 'Make a review'];
-const settings = ['My Products','My Reviews', 'Logout'];
+const pages = ['Home', 'Post a product', 'Make a review'];
+const settings = ['My Products', 'My Reviews', 'Logout'];
 
 const Topbar = () => {
-  const [anchorElNav, setAnchorElNav] = React.useState<null | HTMLElement>(null);
-  const [anchorElUser, setAnchorElUser] = React.useState<null | HTMLElement>(null);
+  const [anchorElNav, setAnchorElNav] = React.useState<null | HTMLElement>(
+    null,
+  );
+  const [anchorElUser, setAnchorElUser] = React.useState<null | HTMLElement>(
+    null,
+  );
 
   const handleOpenNavMenu = (event: React.MouseEvent<HTMLElement>) => {
     setAnchorElNav(event.currentTarget);
@@ -39,7 +44,7 @@ const Topbar = () => {
     <AppBar position="static">
       <Container maxWidth="xl">
         <Toolbar disableGutters>
-          <AdbIcon sx={{ display: { xs: 'none', md: 'flex' }, mr: 1 }} />
+          <Reviews sx={{ display: { xs: 'none', md: 'flex' }, mr: 1 }} />
           <Typography
             variant="h6"
             noWrap
@@ -87,7 +92,7 @@ const Topbar = () => {
                 display: { xs: 'block', md: 'none' },
               }}
             >
-              {pages.map((page) => (
+              {pages.map(page => (
                 <MenuItem key={page} onClick={handleCloseNavMenu}>
                   <Typography textAlign="center">{page}</Typography>
                 </MenuItem>
@@ -114,7 +119,7 @@ const Topbar = () => {
             RVWR
           </Typography>
           <Box sx={{ flexGrow: 1, display: { xs: 'none', md: 'flex' } }}>
-            {pages.map((page) => (
+            {pages.map(page => (
               <Button
                 key={page}
                 onClick={handleCloseNavMenu}
@@ -128,7 +133,7 @@ const Topbar = () => {
           <Box sx={{ flexGrow: 0 }}>
             <Tooltip title="Open settings">
               <IconButton onClick={handleOpenUserMenu} sx={{ p: 0 }}>
-                <PersonIcon style={{color: "white"}} />
+                <PersonIcon style={{ color: 'white' }} />
               </IconButton>
             </Tooltip>
             <Menu
@@ -147,7 +152,7 @@ const Topbar = () => {
               open={Boolean(anchorElUser)}
               onClose={handleCloseUserMenu}
             >
-              {settings.map((setting) => (
+              {settings.map(setting => (
                 <MenuItem key={setting} onClick={handleCloseUserMenu}>
                   <Typography textAlign="center">{setting}</Typography>
                 </MenuItem>

--- a/packages/web/src/graphql/fetchGraphql.ts
+++ b/packages/web/src/graphql/fetchGraphql.ts
@@ -1,10 +1,8 @@
 async function fetchGraphQL(text: string, variables?: any) {
-
-  // Fetch data from GitHub's GraphQL API:
   const response = await fetch('http://localhost:3000/graphql', {
     method: 'POST',
     headers: {
-     // Authorization: `JWT jwt token here`,
+      Authorization: `JWT ${localStorage.getItem('CHALLENGE-TOKEN')}`,
       'Content-Type': 'application/json',
     },
     body: JSON.stringify({
@@ -13,7 +11,6 @@ async function fetchGraphQL(text: string, variables?: any) {
     }),
   });
 
-  // Get the response as JSON
   return await response.json();
 }
 

--- a/packages/web/src/modules/auth/AuthLoginMutation.ts
+++ b/packages/web/src/modules/auth/AuthLoginMutation.ts
@@ -1,0 +1,15 @@
+import { graphql } from 'react-relay';
+
+export const AuthLoginMutation = graphql`
+  mutation AuthLoginMutation($email: String!, $password: String!) {
+    LoginWithEmailMutation(input: { email: $email, password: $password }) {
+      token
+      error
+      me {
+        name
+        email
+        _id
+      }
+    }
+  }
+`;

--- a/packages/web/src/modules/auth/AuthRoutes.tsx
+++ b/packages/web/src/modules/auth/AuthRoutes.tsx
@@ -1,0 +1,10 @@
+import { Route, Routes } from 'react-router-dom';
+import { LoginPage } from './LoginPage';
+
+export const AuthRoutes = () => {
+  return (
+    <Routes>
+      <Route path="login" element={<LoginPage />} />
+    </Routes>
+  );
+};

--- a/packages/web/src/modules/auth/LoginPage.tsx
+++ b/packages/web/src/modules/auth/LoginPage.tsx
@@ -1,0 +1,141 @@
+import { Container } from '@mui/system';
+import { useMutation } from 'react-relay';
+import * as Yup from 'yup';
+import { Form, FormikProvider, useFormik } from 'formik';
+import { AuthLoginMutation } from './AuthLoginMutation';
+import { useState } from 'react';
+import {
+  CssBaseline,
+  Box,
+  Avatar,
+  Typography,
+  Button,
+  Grid,
+  Link,
+  Snackbar,
+  Alert,
+} from '@mui/material';
+import { InputField } from '../../components/InputField';
+import Reviews from '@mui/icons-material/Reviews';
+import type { AuthLoginMutation as AuthLoginMutationType } from './__generated__/AuthLoginMutation.graphql';
+
+export const LoginPage = () => {
+  const [error, setError] = useState({
+    status: false,
+    message: '',
+  });
+
+  const [handleUserLogin] =
+    useMutation<AuthLoginMutationType>(AuthLoginMutation);
+
+  const formikValue = useFormik({
+    initialValues: { email: '', password: '' },
+    validateOnMount: true,
+    validationSchema: Yup.object().shape({
+      email: Yup.string().email().required('Email is required'),
+      password: Yup.string().required('Password is required'),
+    }),
+    onSubmit: (values, actions) => {
+      handleUserLogin({
+        variables: values,
+        onCompleted: ({ LoginWithEmailMutation }) => {
+          if (LoginWithEmailMutation?.error) {
+            actions.setSubmitting(false);
+            setError({ message: LoginWithEmailMutation.error, status: true });
+            return;
+          }
+
+          if (LoginWithEmailMutation?.token) {
+            localStorage.setItem(
+              'CHALLENGE-TOKEN',
+              LoginWithEmailMutation?.token,
+            );
+          }
+
+          return;
+        },
+      });
+    },
+  });
+
+  const { isValid, isSubmitting } = formikValue;
+
+  return (
+    <div>
+      <FormikProvider value={formikValue}>
+        <Container component="main" maxWidth="xs">
+          <Form style={{ width: '100%' }}>
+            <CssBaseline />
+            <Box
+              sx={{
+                marginTop: 8,
+                display: 'flex',
+                flexDirection: 'column',
+                alignItems: 'center',
+                width: '100%',
+              }}
+            >
+              <Avatar sx={{ m: 1, bgcolor: 'primary.main' }}>
+                <Reviews />
+              </Avatar>
+              <Typography component="h1" variant="h5">
+                Sign in to reviewer
+              </Typography>
+              <Box
+                sx={{
+                  mt: 5,
+                  width: '100%',
+                  display: 'flex',
+                  flexDirection: 'column',
+                  gap: '20px',
+                }}
+              >
+                <InputField
+                  required
+                  id="email"
+                  name="email"
+                  autoComplete="email"
+                  autoFocus
+                  shouldValidate
+                  placeholder="email@valid.com"
+                />
+                <InputField
+                  required
+                  fullWidth
+                  name="password"
+                  type="password"
+                  id="password"
+                  shouldValidate
+                  placeholder="password"
+                />
+                <Button
+                  type="submit"
+                  fullWidth
+                  variant="contained"
+                  sx={{ mt: 3, mb: 2 }}
+                  disabled={!isValid}
+                >
+                  {isSubmitting ? 'Loading...' : 'Sign In'}
+                </Button>
+                <Grid container>
+                  <Grid item xs={12} justifyContent="center" display={'flex'}>
+                    <Link href="#" variant="body2">
+                      {"Don't have an account? Sign Up"}
+                    </Link>
+                  </Grid>
+                </Grid>
+              </Box>
+            </Box>
+          </Form>
+        </Container>
+      </FormikProvider>
+      <Snackbar
+        open={error.status}
+        message={error.message}
+        autoHideDuration={5000}
+      >
+        <Alert severity="error">{error.message}</Alert>
+      </Snackbar>
+    </div>
+  );
+};

--- a/packages/web/src/modules/auth/__generated__/AuthLoginMutation.graphql.ts
+++ b/packages/web/src/modules/auth/__generated__/AuthLoginMutation.graphql.ts
@@ -1,0 +1,191 @@
+/**
+ * @generated SignedSource<<76acff7e602a32d1096cf1f0646544aa>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest, Mutation } from 'relay-runtime';
+export type AuthLoginMutation$variables = {
+  email: string;
+  password: string;
+};
+export type AuthLoginMutation$data = {
+  readonly LoginWithEmailMutation: {
+    readonly error: string | null;
+    readonly me: {
+      readonly _id: string;
+      readonly email: string | null;
+      readonly name: string | null;
+    } | null;
+    readonly token: string | null;
+  } | null;
+};
+export type AuthLoginMutation = {
+  response: AuthLoginMutation$data;
+  variables: AuthLoginMutation$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "email"
+  },
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "password"
+  }
+],
+v1 = [
+  {
+    "fields": [
+      {
+        "kind": "Variable",
+        "name": "email",
+        "variableName": "email"
+      },
+      {
+        "kind": "Variable",
+        "name": "password",
+        "variableName": "password"
+      }
+    ],
+    "kind": "ObjectValue",
+    "name": "input"
+  }
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "token",
+  "storageKey": null
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "error",
+  "storageKey": null
+},
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "email",
+  "storageKey": null
+},
+v6 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "_id",
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "AuthLoginMutation",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "UserLoginWithEmailPayload",
+        "kind": "LinkedField",
+        "name": "LoginWithEmailMutation",
+        "plural": false,
+        "selections": [
+          (v2/*: any*/),
+          (v3/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "User",
+            "kind": "LinkedField",
+            "name": "me",
+            "plural": false,
+            "selections": [
+              (v4/*: any*/),
+              (v5/*: any*/),
+              (v6/*: any*/)
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "AuthLoginMutation",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "UserLoginWithEmailPayload",
+        "kind": "LinkedField",
+        "name": "LoginWithEmailMutation",
+        "plural": false,
+        "selections": [
+          (v2/*: any*/),
+          (v3/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "User",
+            "kind": "LinkedField",
+            "name": "me",
+            "plural": false,
+            "selections": [
+              (v4/*: any*/),
+              (v5/*: any*/),
+              (v6/*: any*/),
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "id",
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "27c6484c2f1ac0cdc85cc98f5b1390e0",
+    "id": null,
+    "metadata": {},
+    "name": "AuthLoginMutation",
+    "operationKind": "mutation",
+    "text": "mutation AuthLoginMutation(\n  $email: String!\n  $password: String!\n) {\n  LoginWithEmailMutation(input: {email: $email, password: $password}) {\n    token\n    error\n    me {\n      name\n      email\n      _id\n      id\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "719ee076b1825698e488b6602413cf18";
+
+export default node;

--- a/packages/web/src/modules/auth/__generated__/LoginPageQuery.graphql.ts
+++ b/packages/web/src/modules/auth/__generated__/LoginPageQuery.graphql.ts
@@ -1,0 +1,335 @@
+/**
+ * @generated SignedSource<<b97d8d13eba881adc356c5da3a5b7be5>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest, Query } from 'relay-runtime';
+export type LoginPageQuery$variables = {};
+export type LoginPageQuery$data = {
+  readonly products: {
+    readonly count: number | null;
+    readonly edges: ReadonlyArray<{
+      readonly node: {
+        readonly _id: string;
+        readonly description: string | null;
+        readonly name: string | null;
+        readonly reviews: {
+          readonly edges: ReadonlyArray<{
+            readonly node: {
+              readonly comment: string | null;
+              readonly rating: number | null;
+              readonly user: {
+                readonly email: string | null;
+                readonly name: string | null;
+              } | null;
+            } | null;
+          } | null>;
+        };
+        readonly user: {
+          readonly email: string | null;
+          readonly name: string | null;
+        } | null;
+      } | null;
+    } | null>;
+  };
+};
+export type LoginPageQuery = {
+  response: LoginPageQuery$data;
+  variables: LoginPageQuery$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "count",
+  "storageKey": null
+},
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "description",
+  "storageKey": null
+},
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "_id",
+  "storageKey": null
+},
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "comment",
+  "storageKey": null
+},
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "rating",
+  "storageKey": null
+},
+v6 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "email",
+  "storageKey": null
+},
+v7 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "LoginPageQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "ProductConnection",
+        "kind": "LinkedField",
+        "name": "products",
+        "plural": false,
+        "selections": [
+          (v0/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "ProductEdge",
+            "kind": "LinkedField",
+            "name": "edges",
+            "plural": true,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "Product",
+                "kind": "LinkedField",
+                "name": "node",
+                "plural": false,
+                "selections": [
+                  (v1/*: any*/),
+                  (v2/*: any*/),
+                  (v3/*: any*/),
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "ReviewConnection",
+                    "kind": "LinkedField",
+                    "name": "reviews",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "ReviewEdge",
+                        "kind": "LinkedField",
+                        "name": "edges",
+                        "plural": true,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "Comment",
+                            "kind": "LinkedField",
+                            "name": "node",
+                            "plural": false,
+                            "selections": [
+                              (v4/*: any*/),
+                              (v5/*: any*/),
+                              {
+                                "alias": null,
+                                "args": null,
+                                "concreteType": "User",
+                                "kind": "LinkedField",
+                                "name": "user",
+                                "plural": false,
+                                "selections": [
+                                  (v6/*: any*/),
+                                  (v2/*: any*/)
+                                ],
+                                "storageKey": null
+                              }
+                            ],
+                            "storageKey": null
+                          }
+                        ],
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "User",
+                    "kind": "LinkedField",
+                    "name": "user",
+                    "plural": false,
+                    "selections": [
+                      (v2/*: any*/),
+                      (v6/*: any*/)
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "LoginPageQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "ProductConnection",
+        "kind": "LinkedField",
+        "name": "products",
+        "plural": false,
+        "selections": [
+          (v0/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "ProductEdge",
+            "kind": "LinkedField",
+            "name": "edges",
+            "plural": true,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "Product",
+                "kind": "LinkedField",
+                "name": "node",
+                "plural": false,
+                "selections": [
+                  (v1/*: any*/),
+                  (v2/*: any*/),
+                  (v3/*: any*/),
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "ReviewConnection",
+                    "kind": "LinkedField",
+                    "name": "reviews",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "ReviewEdge",
+                        "kind": "LinkedField",
+                        "name": "edges",
+                        "plural": true,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "Comment",
+                            "kind": "LinkedField",
+                            "name": "node",
+                            "plural": false,
+                            "selections": [
+                              (v4/*: any*/),
+                              (v5/*: any*/),
+                              {
+                                "alias": null,
+                                "args": null,
+                                "concreteType": "User",
+                                "kind": "LinkedField",
+                                "name": "user",
+                                "plural": false,
+                                "selections": [
+                                  (v6/*: any*/),
+                                  (v2/*: any*/),
+                                  (v7/*: any*/)
+                                ],
+                                "storageKey": null
+                              },
+                              (v7/*: any*/)
+                            ],
+                            "storageKey": null
+                          }
+                        ],
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "User",
+                    "kind": "LinkedField",
+                    "name": "user",
+                    "plural": false,
+                    "selections": [
+                      (v2/*: any*/),
+                      (v6/*: any*/),
+                      (v7/*: any*/)
+                    ],
+                    "storageKey": null
+                  },
+                  (v7/*: any*/)
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "453d152360a5d8afbcf643a4965d645a",
+    "id": null,
+    "metadata": {},
+    "name": "LoginPageQuery",
+    "operationKind": "query",
+    "text": "query LoginPageQuery {\n  products {\n    count\n    edges {\n      node {\n        description\n        name\n        _id\n        reviews {\n          edges {\n            node {\n              comment\n              rating\n              user {\n                email\n                name\n                id\n              }\n              id\n            }\n          }\n        }\n        user {\n          name\n          email\n          id\n        }\n        id\n      }\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "17f39870c7ef530aa52ffba98f3611cd";
+
+export default node;

--- a/yarn.lock
+++ b/yarn.lock
@@ -994,7 +994,7 @@
     core-js-pure "^3.25.1"
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.10.2", "@babel/runtime@^7.12.5", "@babel/runtime@^7.18.3", "@babel/runtime@^7.18.9", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7":
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.10.2", "@babel/runtime@^7.12.5", "@babel/runtime@^7.15.4", "@babel/runtime@^7.18.3", "@babel/runtime@^7.18.9", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7":
   version "7.19.0"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.19.0.tgz#22b11c037b094d27a8a2504ea4dcff00f50e2259"
   integrity sha512-eR8Lo9hnDS7tqkO7NsV+mKvCmv5boaXFSZ70DnfhcgiEne8hv9oCEd36Klw74EtizEqLsy4YnW8UWwpBVolHZA==
@@ -2033,6 +2033,11 @@
   resolved "https://registry.npmjs.org/@popperjs/core/-/core-2.11.6.tgz"
   integrity sha512-50/17A98tWUfQ176raKiOGXuYpLyyVMkxxG6oylzL3BPOlA6ADGdK7EYunSa4I064xerltq9TGXs8HmOk5E+vw==
 
+"@remix-run/router@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@remix-run/router/-/router-1.0.0.tgz#a2189335a5f6428aa904ccc291988567018b6e01"
+  integrity sha512-SCR1cxRSMNKjaVYptCzBApPDqGwa3FGdjVHc+rOToocNPHQdIYLZBfv/3f+KvYuXDkUGVIW9IAzmPNZDRL1I4A==
+
 "@sinclair/typebox@^0.24.1":
   version "0.24.41"
   resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.24.41.tgz#45470b8bae32a28f1e0501066d0bacbd8b772804"
@@ -2310,6 +2315,11 @@
     "@types/keygrip" "*"
     "@types/koa-compose" "*"
     "@types/node" "*"
+
+"@types/lodash@^4.14.175":
+  version "4.14.185"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.185.tgz#c9843f5a40703a8f5edfd53358a58ae729816908"
+  integrity sha512-evMDG1bC4rgQg4ku9tKpuMh5iBNEwNa3tf9zRHdP1qlv+1WUg44xat4IxCE14gIpZRGUUWAx2VhItCZc25NfMA==
 
 "@types/mime@*":
   version "3.0.1"
@@ -3931,6 +3941,11 @@ deep-is@^0.1.3:
   resolved "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz"
   integrity sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==
 
+deepmerge@^2.1.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-2.2.1.tgz#5d3ff22a01c00f645405a2fbc17d0778a1801170"
+  integrity sha512-R9hc1Xa/NOBi9WRVUWg19rl1UB7Tt4kuPd+thNJgFZoxXsTz7ncaPaeIm+40oSGuP33DfMb4sZt1QIGiJzC4EA==
+
 deepmerge@^4.2.2:
   version "4.2.2"
   resolved "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz"
@@ -4966,6 +4981,19 @@ formidable@^2.0.1:
     once "1.4.0"
     qs "6.9.3"
 
+formik@^2.2.9:
+  version "2.2.9"
+  resolved "https://registry.yarnpkg.com/formik/-/formik-2.2.9.tgz#8594ba9c5e2e5cf1f42c5704128e119fc46232d0"
+  integrity sha512-LQLcISMmf1r5at4/gyJigGn0gOwFbeEAlji+N9InZF6LIMXnFNkO42sCI8Jt84YZggpD4cPWObAZaxpEFtSzNA==
+  dependencies:
+    deepmerge "^2.1.1"
+    hoist-non-react-statics "^3.3.0"
+    lodash "^4.17.21"
+    lodash-es "^4.17.21"
+    react-fast-compare "^2.0.1"
+    tiny-warning "^1.0.2"
+    tslib "^1.10.0"
+
 fresh@~0.5.2:
   version "0.5.2"
   resolved "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz"
@@ -5422,7 +5450,7 @@ hexoid@1.0.0:
   resolved "https://registry.npmjs.org/hexoid/-/hexoid-1.0.0.tgz"
   integrity sha512-QFLV0taWQOZtvIRIAdBChesmogZrtuXvVWsFHZTk2SU+anspqZ2vMnoLg7IE1+Uk16N19APic1BuF8bC8c2m5g==
 
-hoist-non-react-statics@^3.3.1:
+hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.1:
   version "3.3.2"
   resolved "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz"
   integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
@@ -6781,6 +6809,11 @@ locate-path@^6.0.0:
   dependencies:
     p-locate "^5.0.0"
 
+lodash-es@^4.17.21:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.21.tgz#43e626c46e6591b7750beb2b50117390c609e3ee"
+  integrity sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==
+
 lodash.debounce@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
@@ -7186,6 +7219,11 @@ mute-stream@0.0.8:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d"
   integrity sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==
+
+nanoclone@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/nanoclone/-/nanoclone-0.2.1.tgz#dd4090f8f1a110d26bb32c49ed2f5b9235209ed4"
+  integrity sha512-wynEP02LmIbLpcYw8uBKpcfF6dmg2vcpKqxeH5UcoKEYdExslsdUA4ugFauuaeYdTB76ez6gJW8XAZ6CgkXYxA==
 
 nanoid@^3.3.4:
   version "3.3.4"
@@ -7894,6 +7932,11 @@ prop-types@^15.6.2, prop-types@^15.8.1:
     object-assign "^4.1.1"
     react-is "^16.13.1"
 
+property-expr@^2.0.4:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/property-expr/-/property-expr-2.0.5.tgz#278bdb15308ae16af3e3b9640024524f4dc02cb4"
+  integrity sha512-IJUkICM5dP5znhCckHSv30Q4b5/JA5enCtkRHYaOVOAocnH/1BQEYTC5NMfT3AVl/iXKdr3aqQbQn9DxyWknwA==
+
 psl@^1.1.28:
   version "1.9.0"
   resolved "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz"
@@ -7979,6 +8022,11 @@ react-dom@^18.2.0:
     loose-envify "^1.1.0"
     scheduler "^0.23.0"
 
+react-fast-compare@^2.0.1:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-2.0.4.tgz#e84b4d455b0fec113e0402c329352715196f81f9"
+  integrity sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw==
+
 react-is@^16.13.1, react-is@^16.7.0:
   version "16.13.1"
   resolved "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz"
@@ -8009,6 +8057,20 @@ react-relay@^14.1.0:
     invariant "^2.2.4"
     nullthrows "^1.1.1"
     relay-runtime "14.1.0"
+
+react-router-dom@^6.4.0:
+  version "6.4.0"
+  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-6.4.0.tgz#a7d7c394c9e730b045cdd4f5d6c2d1ccb9e26947"
+  integrity sha512-4Aw1xmXKeleYYQ3x0Lcl2undHR6yMjXZjd9DKZd53SGOYqirrUThyUb0wwAX5VZAyvSuzjNJmZlJ3rR9+/vzqg==
+  dependencies:
+    react-router "6.4.0"
+
+react-router@6.4.0:
+  version "6.4.0"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-6.4.0.tgz#68449c23dc893fc7a57db068c19987be1de72edb"
+  integrity sha512-B+5bEXFlgR1XUdHYR6P94g299SjrfCBMmEDJNcFbpAyRH1j1748yt9NdDhW3++nw1lk3zQJ6aOO66zUx3KlTZg==
+  dependencies:
+    "@remix-run/router" "1.0.0"
 
 react-transition-group@^4.4.5:
   version "4.4.5"
@@ -9020,6 +9082,11 @@ tiny-glob@^0.2.9:
     globalyzer "0.1.0"
     globrex "^0.1.2"
 
+tiny-warning@^1.0.2:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/tiny-warning/-/tiny-warning-1.0.3.tgz#94a30db453df4c643d0fd566060d60a875d84754"
+  integrity sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==
+
 tmp@0.2.1, tmp@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.2.1.tgz#8457fc3037dcf4719c251367a1af6500ee1ccf14"
@@ -9065,6 +9132,11 @@ toidentifier@1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz"
   integrity sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==
+
+toposort@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/toposort/-/toposort-2.0.2.tgz#ae21768175d1559d48bef35420b2f4962f09c330"
+  integrity sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg==
 
 tough-cookie@~2.5.0:
   version "2.5.0"
@@ -9712,6 +9784,19 @@ yocto-queue@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
+
+yup@^0.32.11:
+  version "0.32.11"
+  resolved "https://registry.yarnpkg.com/yup/-/yup-0.32.11.tgz#d67fb83eefa4698607982e63f7ca4c5ed3cf18c5"
+  integrity sha512-Z2Fe1bn+eLstG8DRR6FTavGD+MeAwyfmouhHsIUgaADz8jvFKbO/fXc2trJKZg+5EBjh4gGm3iU/t3onKlXHIg==
+  dependencies:
+    "@babel/runtime" "^7.15.4"
+    "@types/lodash" "^4.14.175"
+    lodash "^4.17.21"
+    lodash-es "^4.17.21"
+    nanoclone "^0.2.1"
+    property-expr "^2.0.4"
+    toposort "^2.0.2"
 
 zen-observable-ts@^1.1.0:
   version "1.1.0"


### PR DESCRIPTION
In this PR I introduced the basic login logic for the app. 

- Added Formik / React-router packages to deal with the login page and forms
- Created the login mutation file for the relay compiler
- Created a basic login form and implemented using formik package

With this the user can already try to login using the ```/login``` route, and will get a visual feedback on errors, on a successfull login, the JWT token from the backend will be stored at the local browser storage under the ```CHALLENGE-TOKEN``` flag.

