### PR TITLE
feat(web): adding register user page and mutation

### DIFF
--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -1,13 +1,16 @@
 import Topbar from './components/Topbar';
 import { Routes } from './Routes';
 import { BrowserRouter } from 'react-router-dom';
+import { AuthProvider } from './modules/auth/utils/AuthContext';
 
 function App() {
   return (
     <div>
       <Topbar />
       <BrowserRouter>
-        <Routes />
+        <AuthProvider>
+          <Routes />
+        </AuthProvider>
       </BrowserRouter>
     </div>
   );

--- a/packages/web/src/modules/auth/AuthRegisterMutation.ts
+++ b/packages/web/src/modules/auth/AuthRegisterMutation.ts
@@ -1,0 +1,21 @@
+import { graphql } from 'react-relay';
+
+export const AuthRegisterMutation = graphql`
+  mutation AuthRegisterMutation(
+    $email: String!
+    $password: String!
+    $name: String!
+  ) {
+    RegisterWithEmailMutation(
+      input: { email: $email, password: $password, name: $name }
+    ) {
+      token
+      error
+      me {
+        name
+        email
+        _id
+      }
+    }
+  }
+`;

--- a/packages/web/src/modules/auth/AuthRoutes.tsx
+++ b/packages/web/src/modules/auth/AuthRoutes.tsx
@@ -1,10 +1,12 @@
 import { Route, Routes } from 'react-router-dom';
 import { LoginPage } from './LoginPage';
+import { RegisterPage } from './RegisterPage';
 
 export const AuthRoutes = () => {
   return (
     <Routes>
       <Route path="login" element={<LoginPage />} />
+      <Route path="register" element={<RegisterPage />} />
     </Routes>
   );
 };

--- a/packages/web/src/modules/auth/__generated__/AuthRegisterMutation.graphql.ts
+++ b/packages/web/src/modules/auth/__generated__/AuthRegisterMutation.graphql.ts
@@ -1,0 +1,208 @@
+/**
+ * @generated SignedSource<<f62cf3f6aa42ef43b71ed89e1b80d2d4>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest, Mutation } from 'relay-runtime';
+export type AuthRegisterMutation$variables = {
+  email: string;
+  name: string;
+  password: string;
+};
+export type AuthRegisterMutation$data = {
+  readonly RegisterWithEmailMutation: {
+    readonly error: string | null;
+    readonly me: {
+      readonly _id: string;
+      readonly email: string | null;
+      readonly name: string | null;
+    } | null;
+    readonly token: string | null;
+  } | null;
+};
+export type AuthRegisterMutation = {
+  response: AuthRegisterMutation$data;
+  variables: AuthRegisterMutation$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "email"
+},
+v1 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "name"
+},
+v2 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "password"
+},
+v3 = [
+  {
+    "fields": [
+      {
+        "kind": "Variable",
+        "name": "email",
+        "variableName": "email"
+      },
+      {
+        "kind": "Variable",
+        "name": "name",
+        "variableName": "name"
+      },
+      {
+        "kind": "Variable",
+        "name": "password",
+        "variableName": "password"
+      }
+    ],
+    "kind": "ObjectValue",
+    "name": "input"
+  }
+],
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "token",
+  "storageKey": null
+},
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "error",
+  "storageKey": null
+},
+v6 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v7 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "email",
+  "storageKey": null
+},
+v8 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "_id",
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": [
+      (v0/*: any*/),
+      (v1/*: any*/),
+      (v2/*: any*/)
+    ],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "AuthRegisterMutation",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v3/*: any*/),
+        "concreteType": "UserRegisterWithEmailPayload",
+        "kind": "LinkedField",
+        "name": "RegisterWithEmailMutation",
+        "plural": false,
+        "selections": [
+          (v4/*: any*/),
+          (v5/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "User",
+            "kind": "LinkedField",
+            "name": "me",
+            "plural": false,
+            "selections": [
+              (v6/*: any*/),
+              (v7/*: any*/),
+              (v8/*: any*/)
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [
+      (v0/*: any*/),
+      (v2/*: any*/),
+      (v1/*: any*/)
+    ],
+    "kind": "Operation",
+    "name": "AuthRegisterMutation",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v3/*: any*/),
+        "concreteType": "UserRegisterWithEmailPayload",
+        "kind": "LinkedField",
+        "name": "RegisterWithEmailMutation",
+        "plural": false,
+        "selections": [
+          (v4/*: any*/),
+          (v5/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "User",
+            "kind": "LinkedField",
+            "name": "me",
+            "plural": false,
+            "selections": [
+              (v6/*: any*/),
+              (v7/*: any*/),
+              (v8/*: any*/),
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "id",
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "ba92c571566f0de2846fa020d68394c5",
+    "id": null,
+    "metadata": {},
+    "name": "AuthRegisterMutation",
+    "operationKind": "mutation",
+    "text": "mutation AuthRegisterMutation(\n  $email: String!\n  $password: String!\n  $name: String!\n) {\n  RegisterWithEmailMutation(input: {email: $email, password: $password, name: $name}) {\n    token\n    error\n    me {\n      name\n      email\n      _id\n      id\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "4647328e79c12f81dfcae7642afd70c8";
+
+export default node;

--- a/packages/web/src/modules/auth/utils/AuthContext.tsx
+++ b/packages/web/src/modules/auth/utils/AuthContext.tsx
@@ -1,0 +1,43 @@
+import React, { useState, useMemo, useCallback } from 'react';
+
+import { getAuthToken, updateAuthToken } from './security';
+
+export type Maybe<T> = T | null | undefined;
+
+export interface AuthContextValue {
+  token: Maybe<string> | undefined;
+  signin: (token: Maybe<string> | undefined, cb: VoidFunction) => void;
+  signout: (cb: VoidFunction) => void;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+export const AuthContext = React.createContext<AuthContextValue>(null!);
+
+export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
+  const [userToken, setUserToken] = useState<AuthContextValue['token']>(() =>
+    getAuthToken(),
+  );
+
+  const signin = useCallback<AuthContextValue['signin']>((token, cb) => {
+    updateAuthToken(token);
+    setUserToken(token);
+    cb();
+  }, []);
+
+  const signout = useCallback<AuthContextValue['signout']>(cb => {
+    setUserToken(null);
+    updateAuthToken();
+    cb();
+  }, []);
+
+  const value = useMemo<AuthContextValue>(
+    () => ({
+      token: userToken,
+      signin,
+      signout,
+    }),
+    [userToken, signin, signout],
+  );
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+};

--- a/packages/web/src/modules/auth/utils/RequireAuthLayout.tsx
+++ b/packages/web/src/modules/auth/utils/RequireAuthLayout.tsx
@@ -1,0 +1,14 @@
+import { Navigate, Outlet, useLocation } from 'react-router-dom';
+
+import { useAuth } from './useAuth';
+
+export const RequireAuthLayout = () => {
+  const location = useLocation();
+  const { token } = useAuth();
+
+  if (!token) {
+    return <Navigate to="/" state={{ from: location }} />;
+  }
+
+  return <Outlet />;
+};

--- a/packages/web/src/modules/auth/utils/security.ts
+++ b/packages/web/src/modules/auth/utils/security.ts
@@ -1,0 +1,13 @@
+import { Maybe } from './AuthContext';
+
+const JWT_TOKEN_KEY = 'CHALLENGE-TOKEN';
+
+export const getAuthToken = () => localStorage.getItem(JWT_TOKEN_KEY);
+
+export const updateAuthToken = (token?: Maybe<string>) => {
+  if (!token) {
+    localStorage.removeItem(JWT_TOKEN_KEY);
+  } else {
+    localStorage.setItem(JWT_TOKEN_KEY, token);
+  }
+};

--- a/packages/web/src/modules/auth/utils/useAuth.tsx
+++ b/packages/web/src/modules/auth/utils/useAuth.tsx
@@ -1,0 +1,5 @@
+import { useContext } from 'react';
+
+import { AuthContext } from './AuthContext';
+
+export const useAuth = () => useContext(AuthContext);


### PR DESCRIPTION
Is this PR i'm adding the Register User functions, page and mutation, as well as authentication features and utils. 

Both register and login routes now redirect to the homepage on success and store the token to the local storage as expected.