### PR TITLE
Adding reviews for products / Refactoring schema

### DIFF
--- a/packages/server/src/modules/review/ReviewType.ts
+++ b/packages/server/src/modules/review/ReviewType.ts
@@ -1,7 +1,17 @@
-import { GraphQLObjectType, GraphQLString, GraphQLNonNull, GraphQLInt, GraphQLBoolean } from 'graphql';
+import {
+  GraphQLObjectType,
+  GraphQLString,
+  GraphQLNonNull,
+  GraphQLInt,
+  GraphQLBoolean,
+} from 'graphql';
 import { globalIdField } from 'graphql-relay';
 
-import { connectionDefinitions, objectIdResolver, timestampResolver } from '@entria/graphql-mongo-helpers';
+import {
+  connectionDefinitions,
+  objectIdResolver,
+  timestampResolver,
+} from '@entria/graphql-mongo-helpers';
 
 import { nodeInterface, registerTypeLoader } from '../node/typeRegister';
 
@@ -15,11 +25,11 @@ import { load } from './ReviewLoader';
 
 //@ts-ignore
 const ReviewType = new GraphQLObjectType<IReview, GraphQLContext>({
-  name: 'Comment',
-  description: 'Comment data',
+  name: 'Review',
+  description: 'Review data',
   //@ts-ignore
   fields: () => ({
-    id: globalIdField('Comment'),
+    id: globalIdField('Review'),
     ...objectIdResolver,
     comment: {
       type: GraphQLString,
@@ -34,7 +44,8 @@ const ReviewType = new GraphQLObjectType<IReview, GraphQLContext>({
     },
     product: {
       type: ProductType,
-      resolve: (review, _, context) => ProductLoader.load(context, review.product),
+      resolve: (review, _, context) =>
+        ProductLoader.load(context, review.product),
     },
     ...timestampResolver,
   }),

--- a/packages/server/src/modules/review/mutations/CreateReviewMutation.ts
+++ b/packages/server/src/modules/review/mutations/CreateReviewMutation.ts
@@ -1,7 +1,18 @@
-import { GraphQLString, GraphQLNonNull, GraphQLID, GraphQLInt } from 'graphql';
+import {
+  GraphQLString,
+  GraphQLNonNull,
+  GraphQLID,
+  GraphQLInt,
+  graphql,
+} from 'graphql';
 import { mutationWithClientMutationId, toGlobalId } from 'graphql-relay';
 
-import { errorField, successField, getObjectId, objectIdResolver } from '@entria/graphql-mongo-helpers';
+import {
+  errorField,
+  successField,
+  getObjectId,
+  objectIdResolver,
+} from '@entria/graphql-mongo-helpers';
 
 import { GraphQLContext } from '../../../graphql/types';
 import ProductModel from '../../product/ProductModel';
@@ -13,7 +24,7 @@ import ProductType from '../../product/ProductType';
 import * as ProductLoader from '../../product/ProductLoader';
 
 type Args = {
-  rating: number;
+  rating: string;
   comment?: string;
   product: string;
 };
@@ -21,7 +32,7 @@ const mutation = mutationWithClientMutationId({
   name: 'CreateReviewMutation',
   inputFields: {
     rating: {
-      type: new GraphQLNonNull(GraphQLInt),
+      type: new GraphQLNonNull(GraphQLString),
     },
     comment: {
       type: GraphQLString,
@@ -57,7 +68,7 @@ const mutation = mutationWithClientMutationId({
       user: context.user._id,
       product,
       comment: args.comment,
-      rating: args.rating,
+      rating: parseInt(args.rating),
     }).save();
 
     return {

--- a/packages/server/src/utils/graphqlSettingsPerReq.ts
+++ b/packages/server/src/utils/graphqlSettingsPerReq.ts
@@ -6,7 +6,11 @@ import { schema } from '../schema/schema';
 import { getContext } from './getContext';
 import { setCookie } from './setCookie';
 
-export const graphqlSettingsPerReq = async (req: Request, ctx: any, koaContext: Context) => {
+export const graphqlSettingsPerReq = async (
+  req: Request,
+  ctx: any,
+  koaContext: Context,
+) => {
   const { user } = await getUser(req.header.authorization);
 
   return {

--- a/packages/web/schema.graphql
+++ b/packages/web/schema.graphql
@@ -45,7 +45,7 @@ interface Connection {
 }
 
 input CreateReviewMutationInput {
-  rating: Int!
+  rating: String!
   comment: String
   product: String!
   clientMutationId: String

--- a/packages/web/src/components/InputField.tsx
+++ b/packages/web/src/components/InputField.tsx
@@ -2,11 +2,29 @@ import {
   FormControl,
   FormErrorMessage,
   Input as ChakraInput,
+  Textarea,
   InputProps,
+  TextareaProps,
+  NumberInput,
+  NumberInputProps,
+  NumberInputField,
+  NumberInputStepper,
+  NumberIncrementStepper,
+  NumberDecrementStepper,
 } from '@chakra-ui/react';
 import { ErrorMessage, useField } from 'formik';
 
 type Props = InputProps & {
+  name: string;
+  shouldValidate?: boolean;
+};
+
+type TextAreaProps = TextareaProps & {
+  name: string;
+  shouldValidate?: boolean;
+};
+
+type CustomNumberInputProps = NumberInputProps & {
   name: string;
   shouldValidate?: boolean;
 };
@@ -27,6 +45,39 @@ export const InputField = ({
   return (
     <FormControl {...(shouldValidate ? propsWhenShouldValidateProps : {})}>
       <ChakraInput {...field} {...rest} />
+      {shouldValidate && (
+        <ErrorMessage name={name}>
+          {error => (
+            <FormErrorMessage
+              data-testid={`error-message-${name}`}
+              fontSize="xs"
+              pt={1}
+            >
+              {error}
+            </FormErrorMessage>
+          )}
+        </ErrorMessage>
+      )}
+    </FormControl>
+  );
+};
+
+export const TextInputField = ({
+  name,
+  shouldValidate = false,
+  ...rest
+}: TextAreaProps) => {
+  const [field, meta] = useField(name);
+
+  const hasAnErrorAndHasBeenTouched = !!meta.error && meta.touched;
+
+  const propsWhenShouldValidateProps = {
+    isInvalid: hasAnErrorAndHasBeenTouched,
+  };
+
+  return (
+    <FormControl {...(shouldValidate ? propsWhenShouldValidateProps : {})}>
+      <Textarea {...field} {...rest} />
       {shouldValidate && (
         <ErrorMessage name={name}>
           {error => (

--- a/packages/web/src/graphql/fetchGraphql.ts
+++ b/packages/web/src/graphql/fetchGraphql.ts
@@ -2,7 +2,7 @@ async function fetchGraphQL(text: string, variables?: any) {
   const response = await fetch('http://localhost:3000/graphql', {
     method: 'POST',
     headers: {
-      Authorization: `JWT ${localStorage.getItem('CHALLENGE-TOKEN')}`,
+      authorization: `${localStorage.getItem('CHALLENGE-TOKEN')}`,
       'Content-Type': 'application/json',
     },
     body: JSON.stringify({

--- a/packages/web/src/modules/products/ProductPage.tsx
+++ b/packages/web/src/modules/products/ProductPage.tsx
@@ -16,16 +16,20 @@ import {
   VisuallyHidden,
   List,
   ListItem,
+  useDisclosure,
 } from '@chakra-ui/react';
 import { useLazyLoadQuery } from 'react-relay';
-import { useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 import { useStore } from '../../store/useStore';
 import { ProductsGetSingleQuery } from './ProductsGetSingleQuery';
+import { ReviewModal } from './ReviewModal';
 import type { ProductsGetSingleQuery as QueryType } from './__generated__/ProductsGetSingleQuery.graphql';
 
 export const ProductPage = () => {
   const params = useParams();
   const store = useStore();
+  const { isOpen, onClose, onOpen } = useDisclosure();
+  const navigate = useNavigate();
 
   const data = useLazyLoadQuery<QueryType>(
     ProductsGetSingleQuery,
@@ -138,11 +142,15 @@ export const ProductPage = () => {
               transform: 'translateY(2px)',
               boxShadow: 'lg',
             }}
+            onClick={() => {
+              store.user ? onOpen() : navigate('/login');
+            }}
           >
             {store.user ? 'Add your review' : 'Login to add a review'}
           </Button>
         </Stack>
       </SimpleGrid>
+      <ReviewModal isOpen={isOpen} onClose={onClose} productId={params.id} />
     </Container>
   );
 };

--- a/packages/web/src/modules/products/ProductsMakeReviewMutation.ts
+++ b/packages/web/src/modules/products/ProductsMakeReviewMutation.ts
@@ -1,0 +1,21 @@
+import { graphql } from 'relay-runtime';
+
+export const ProductsMakeReviewMutation = graphql`
+  mutation ProductsMakeReviewMutation($input: CreateReviewMutationInput!) {
+    CreateReviewMutation(input: $input) {
+      error
+      reviewEdge {
+        node {
+          _id
+          comment
+          rating
+          user {
+            _id
+            name
+            email
+          }
+        }
+      }
+    }
+  }
+`;

--- a/packages/web/src/modules/products/ReviewModal.tsx
+++ b/packages/web/src/modules/products/ReviewModal.tsx
@@ -1,0 +1,102 @@
+import {
+  Modal,
+  ModalOverlay,
+  ModalContent,
+  ModalHeader,
+  ModalBody,
+  ModalCloseButton,
+  Button,
+  FormControl,
+  FormLabel,
+  Stack,
+  Textarea,
+  NumberDecrementStepper,
+  NumberIncrementStepper,
+  NumberInputField,
+  NumberInputStepper,
+} from '@chakra-ui/react';
+import { Form, Formik, FormikProvider, useFormik } from 'formik';
+import { useMutation } from 'react-relay';
+import * as Yup from 'yup';
+import { TextInputField, InputField } from '../../components/InputField';
+import { ProductsMakeReviewMutation } from './ProductsMakeReviewMutation';
+import { ProductsMakeReviewMutation as MutationType } from './__generated__/ProductsMakeReviewMutation.graphql';
+
+interface Props {
+  isOpen: boolean;
+  onClose: () => void;
+  productId: string | undefined;
+}
+
+export const ReviewModal = (props: Props) => {
+  const [commit, isInFlight] = useMutation<MutationType>(
+    ProductsMakeReviewMutation,
+  );
+
+  const formikValue = useFormik({
+    initialValues: { rating: '0', comment: '' },
+    validateOnMount: true,
+    validationSchema: Yup.object().shape({
+      rating: Yup.number().min(0).max(10),
+      comment: Yup.string(),
+    }),
+    onSubmit: (values, actions) => {
+      console.log(values);
+      commit({
+        variables: {
+          input: {
+            rating: values.rating,
+            comment: values.comment,
+            product: props.productId || '000',
+          },
+        },
+        onCompleted: data => {
+          console.log(data);
+          props.onClose();
+        },
+      });
+    },
+  });
+
+  const { isValid } = formikValue;
+
+  return (
+    <Modal isOpen={props.isOpen} onClose={props.onClose}>
+      <ModalOverlay />
+      <ModalContent>
+        <ModalHeader>Post your review</ModalHeader>
+        <ModalCloseButton />
+        <ModalBody>
+          <FormikProvider value={formikValue}>
+            <Form>
+              <Stack spacing={8} mx={'auto'} maxW={'lg'} py={6} px={6}>
+                <Stack spacing={4}>
+                  <FormControl id="rating">
+                    <FormLabel>Rating</FormLabel>
+                    <InputField id="rating" name="rating" shouldValidate />
+                  </FormControl>
+                  <FormControl id="comment">
+                    <FormLabel>Comment</FormLabel>
+                    <TextInputField
+                      id="comment"
+                      name="comment"
+                      placeholder="This product is amazing, or is it..."
+                    />
+                  </FormControl>
+                </Stack>
+              </Stack>
+              <Button
+                disabled={!isValid}
+                type="submit"
+                colorScheme="blue"
+                width={'full'}
+              >
+                Submit Review
+              </Button>
+            </Form>
+          </FormikProvider>
+        </ModalBody>
+      </ModalContent>
+    </Modal>
+  );
+};

--- a/packages/web/src/modules/products/__generated__/ProductsMakeReviewMutation.graphql.ts
+++ b/packages/web/src/modules/products/__generated__/ProductsMakeReviewMutation.graphql.ts
@@ -1,0 +1,243 @@
+/**
+ * @generated SignedSource<<12edc711456353eb78508915cca72fa0>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest, Mutation } from 'relay-runtime';
+export type CreateReviewMutationInput = {
+  clientMutationId?: string | null;
+  comment?: string | null;
+  product: string;
+  rating: string;
+};
+export type ProductsMakeReviewMutation$variables = {
+  input: CreateReviewMutationInput;
+};
+export type ProductsMakeReviewMutation$data = {
+  readonly CreateReviewMutation: {
+    readonly error: string | null;
+    readonly reviewEdge: {
+      readonly node: {
+        readonly _id: string;
+        readonly comment: string | null;
+        readonly rating: number | null;
+        readonly user: {
+          readonly _id: string;
+          readonly email: string | null;
+          readonly name: string | null;
+        } | null;
+      } | null;
+    } | null;
+  } | null;
+};
+export type ProductsMakeReviewMutation = {
+  response: ProductsMakeReviewMutation$data;
+  variables: ProductsMakeReviewMutation$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "input"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "input",
+    "variableName": "input"
+  }
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "error",
+  "storageKey": null
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "_id",
+  "storageKey": null
+},
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "comment",
+  "storageKey": null
+},
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "rating",
+  "storageKey": null
+},
+v6 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v7 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "email",
+  "storageKey": null
+},
+v8 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "ProductsMakeReviewMutation",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "CreateReviewMutationPayload",
+        "kind": "LinkedField",
+        "name": "CreateReviewMutation",
+        "plural": false,
+        "selections": [
+          (v2/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "ReviewEdge",
+            "kind": "LinkedField",
+            "name": "reviewEdge",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "Review",
+                "kind": "LinkedField",
+                "name": "node",
+                "plural": false,
+                "selections": [
+                  (v3/*: any*/),
+                  (v4/*: any*/),
+                  (v5/*: any*/),
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "User",
+                    "kind": "LinkedField",
+                    "name": "user",
+                    "plural": false,
+                    "selections": [
+                      (v3/*: any*/),
+                      (v6/*: any*/),
+                      (v7/*: any*/)
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "ProductsMakeReviewMutation",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "CreateReviewMutationPayload",
+        "kind": "LinkedField",
+        "name": "CreateReviewMutation",
+        "plural": false,
+        "selections": [
+          (v2/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "ReviewEdge",
+            "kind": "LinkedField",
+            "name": "reviewEdge",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "Review",
+                "kind": "LinkedField",
+                "name": "node",
+                "plural": false,
+                "selections": [
+                  (v3/*: any*/),
+                  (v4/*: any*/),
+                  (v5/*: any*/),
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "User",
+                    "kind": "LinkedField",
+                    "name": "user",
+                    "plural": false,
+                    "selections": [
+                      (v3/*: any*/),
+                      (v6/*: any*/),
+                      (v7/*: any*/),
+                      (v8/*: any*/)
+                    ],
+                    "storageKey": null
+                  },
+                  (v8/*: any*/)
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "9ca9c41d170379d1e064bb71e165dd75",
+    "id": null,
+    "metadata": {},
+    "name": "ProductsMakeReviewMutation",
+    "operationKind": "mutation",
+    "text": "mutation ProductsMakeReviewMutation(\n  $input: CreateReviewMutationInput!\n) {\n  CreateReviewMutation(input: $input) {\n    error\n    reviewEdge {\n      node {\n        _id\n        comment\n        rating\n        user {\n          _id\n          name\n          email\n          id\n        }\n        id\n      }\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "94ceeba6818b922e803f3ce778e8e4ff";
+
+export default node;

--- a/yarn.lock
+++ b/yarn.lock
@@ -8835,6 +8835,11 @@ react-focus-lock@^2.9.1:
     use-callback-ref "^1.3.0"
     use-sidecar "^1.1.2"
 
+react-icons@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/react-icons/-/react-icons-4.4.0.tgz#a13a8a20c254854e1ec9aecef28a95cdf24ef703"
+  integrity sha512-fSbvHeVYo/B5/L4VhB7sBA1i2tS8MkT0Hb9t2H1AVPkwGfVHLJCqyr2Py9dKMxsyM63Eng1GkdZfbWj+Fmv8Rg==
+
 react-is@^16.13.1, react-is@^16.7.0:
   version "16.13.1"
   resolved "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz"


### PR DESCRIPTION
# In this PR

## Server 
- Refactored some of the graphql fields for the review creation
- fixed typos

## Cliente / Web
- Logged users can now post a review for a product 
- When not logged in, users can click the review button and go to login page
- Users cannot review their own products ( maybe change this in the future )

## TODO
- Add the "Create Product" Functionality for logged users.
- find a way to force the refresh of the product reviews after a cnew review is added.