### PR TITLE
Adding login persistence / External Link handling

### DIFF
--- a/packages/web/src/components/ExternalLinkWarningl.tsx
+++ b/packages/web/src/components/ExternalLinkWarningl.tsx
@@ -1,0 +1,57 @@
+import {
+  Modal,
+  ModalOverlay,
+  ModalContent,
+  ModalHeader,
+  ModalFooter,
+  ModalBody,
+  ModalCloseButton,
+  Button,
+  Avatar,
+  Text,
+  Link,
+} from '@chakra-ui/react';
+import { useLazyLoadQuery } from 'react-relay';
+import { string } from 'yup';
+import { ProductsGetSingleQuery } from '../modules/products/ProductsGetSingleQuery';
+import type { ProductsGetSingleQuery as QueryType } from '../modules/products/__generated__/ProductsGetSingleQuery.graphql';
+
+interface Props {
+  isOpen: boolean;
+  onClose: () => void;
+  referenceLink: string;
+}
+
+export const ExternalLinkWarning = ({
+  isOpen,
+  onClose,
+  referenceLink,
+}: Props) => {
+  return (
+    <Modal isOpen={isOpen} onClose={onClose}>
+      <ModalOverlay />
+      <ModalContent>
+        <ModalHeader alignItems={'center'} display="flex" gap={'6'}>
+          <Text>Warning</Text>
+        </ModalHeader>
+        <ModalCloseButton />
+        <ModalBody>
+          <Text>
+            You are about to navigate to an external link that doesnt belong to
+            our domain, atention is advised.
+          </Text>
+        </ModalBody>
+        <ModalFooter>
+          <Button colorScheme="blue" mr={3} onClick={onClose}>
+            Close
+          </Button>
+          <Link href={referenceLink} target="_blank">
+            <Button colorScheme="red" mr={3} onClick={onClose}>
+              Continue to external website
+            </Button>
+          </Link>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  );
+};

--- a/packages/web/src/modules/products/CreateProduct.tsx
+++ b/packages/web/src/modules/products/CreateProduct.tsx
@@ -14,17 +14,34 @@ import {
 import * as Yup from 'yup';
 import { Field, Form, FormikProvider, useFormik } from 'formik';
 import { InputField } from '../../components/InputField';
-import { useMutation } from 'react-relay';
+import { useLazyLoadQuery, useMutation } from 'react-relay';
 import { ProductCreateMutation } from './ProductCreateMutation';
 import type { ProductCreateMutation as MutationType } from './__generated__/ProductCreateMutation.graphql';
 import { useNavigate } from 'react-router-dom';
+import { AuthMeQuery } from '../auth/AuthMeQuery';
+import { useEffect } from 'react';
+import { useStore } from '../../store/useStore';
+import { AuthMeQuery as AuthQueryType } from '../auth/__generated__/AuthMeQuery.graphql';
 
 export const CreateProduct = () => {
   const navigate = useNavigate();
+  const store = useStore();
 
   const [handleCreateProduct] = useMutation<MutationType>(
     ProductCreateMutation,
   );
+
+  const authData = useLazyLoadQuery<AuthQueryType>(AuthMeQuery, {});
+
+  useEffect(() => {
+    if (!store.user && localStorage.getItem('CHALLENGE-TOKEN')) {
+      store.setUser({
+        _id: authData.me?._id || '000',
+        email: authData.me?.email || '',
+        name: authData.me?.name || '',
+      });
+    }
+  }, []);
 
   const formikValue = useFormik({
     initialValues: {

--- a/packages/web/src/modules/products/FeedPage.tsx
+++ b/packages/web/src/modules/products/FeedPage.tsx
@@ -1,11 +1,19 @@
 import { Button, Flex } from '@chakra-ui/react';
-import { loadQuery, useMutation, usePreloadedQuery } from 'react-relay';
+import { useEffect } from 'react';
+import {
+  loadQuery,
+  useLazyLoadQuery,
+  useMutation,
+  usePreloadedQuery,
+} from 'react-relay';
 import { useNavigate } from 'react-router-dom';
 import ProductCard from '../../components/ProductCard';
 import relayEnvironment from '../../relay/relayEnvironment';
 import { useStore } from '../../store/useStore';
 import { ProductsGetAllQuery } from './ProductsGetAllQuery';
 import type { ProductsGetAllQuery as QueryType } from './__generated__/ProductsGetAllQuery.graphql';
+import { AuthMeQuery } from '../auth/AuthMeQuery';
+import { AuthMeQuery as MeQueryType } from '../auth/__generated__/AuthMeQuery.graphql';
 
 const preloadedQuery = loadQuery<QueryType>(
   relayEnvironment,
@@ -20,6 +28,17 @@ export const FeedPage = () => {
     ProductsGetAllQuery,
     preloadedQuery,
   );
+  const authData = useLazyLoadQuery<MeQueryType>(AuthMeQuery, {});
+
+  useEffect(() => {
+    if (!store.user && localStorage.getItem('CHALLENGE-TOKEN')) {
+      store.setUser({
+        _id: authData.me?._id || '000',
+        email: authData.me?.email || '',
+        name: authData.me?.name || '',
+      });
+    }
+  }, []);
 
   return (
     <>

--- a/packages/web/src/modules/products/ProductPage.tsx
+++ b/packages/web/src/modules/products/ProductPage.tsx
@@ -1,4 +1,4 @@
-import { StarIcon } from '@chakra-ui/icons';
+import { ExternalLinkIcon, StarIcon } from '@chakra-ui/icons';
 import {
   Box,
   chakra,
@@ -21,6 +21,7 @@ import {
 import { useEffect } from 'react';
 import { useLazyLoadQuery, useMutation } from 'react-relay';
 import { useNavigate, useParams } from 'react-router-dom';
+import { ExternalLinkWarning } from '../../components/ExternalLinkWarningl';
 import { useStore } from '../../store/useStore';
 import { AuthMeQuery } from '../auth/AuthMeQuery';
 import { AuthMeQuery as AuthQueryType } from '../auth/__generated__/AuthMeQuery.graphql';
@@ -35,7 +36,16 @@ import type { ProductsGetSingleQuery as QueryType } from './__generated__/Produc
 export const ProductPage = () => {
   const params = useParams();
   const store = useStore();
-  const { isOpen, onClose, onOpen } = useDisclosure();
+  const {
+    isOpen: isReviewModalOpen,
+    onClose: reviewModalClose,
+    onOpen: reviewModalOpen,
+  } = useDisclosure();
+  const {
+    isOpen: isExternalLinkModalOpen,
+    onClose: externalLinkModalClose,
+    onOpen: externalLinkModalOpen,
+  } = useDisclosure();
   const navigate = useNavigate();
 
   const data = useLazyLoadQuery<QueryType>(
@@ -85,7 +95,7 @@ export const ProductPage = () => {
           />
         </Flex>
         <Stack spacing={{ base: 6, md: 10 }}>
-          <Box as={'header'}>
+          <Flex as={'header'} alignItems="center" gap={'10px'}>
             <Heading
               lineHeight={1.1}
               fontWeight={600}
@@ -93,7 +103,16 @@ export const ProductPage = () => {
             >
               {data.singleProductById?.name}
             </Heading>
-          </Box>
+            {data.singleProductById?.referenceLink ? (
+              <Button
+                rightIcon={<ExternalLinkIcon />}
+                onClick={() => externalLinkModalOpen()}
+                variant={'outline'}
+              >
+                Visit reference link
+              </Button>
+            ) : null}
+          </Flex>
 
           <Stack
             spacing={{ base: 4, sm: 6 }}
@@ -215,14 +234,25 @@ export const ProductPage = () => {
               boxShadow: 'lg',
             }}
             onClick={() => {
-              store.user ? onOpen() : navigate('/login');
+              store.user ? reviewModalOpen() : navigate('/login');
             }}
           >
             {store.user ? 'Add your review' : 'Login to add a review'}
           </Button>
         </Stack>
       </SimpleGrid>
-      <ReviewModal isOpen={isOpen} onClose={onClose} productId={params.id} />
+      <ReviewModal
+        isOpen={isReviewModalOpen}
+        onClose={reviewModalClose}
+        productId={params.id}
+      />
+      <ExternalLinkWarning
+        isOpen={isExternalLinkModalOpen}
+        onClose={externalLinkModalClose}
+        referenceLink={
+          data.singleProductById?.referenceLink || 'www.google.com'
+        }
+      />
     </Container>
   );
 };

--- a/packages/web/src/modules/products/ProductPage.tsx
+++ b/packages/web/src/modules/products/ProductPage.tsx
@@ -18,9 +18,12 @@ import {
   ListItem,
   useDisclosure,
 } from '@chakra-ui/react';
+import { useEffect } from 'react';
 import { useLazyLoadQuery, useMutation } from 'react-relay';
 import { useNavigate, useParams } from 'react-router-dom';
 import { useStore } from '../../store/useStore';
+import { AuthMeQuery } from '../auth/AuthMeQuery';
+import { AuthMeQuery as AuthQueryType } from '../auth/__generated__/AuthMeQuery.graphql';
 import { DeleteProductMutation } from './DeleteProduct';
 import { DeleteReviewMutation } from './DeleteReview';
 import { ProductsGetSingleQuery } from './ProductsGetSingleQuery';
@@ -48,6 +51,18 @@ export const ProductPage = () => {
   );
   const [handleDeleteReview] =
     useMutation<DeleteReviewMutationType>(DeleteReviewMutation);
+
+  const authData = useLazyLoadQuery<AuthQueryType>(AuthMeQuery, {});
+
+  useEffect(() => {
+    if (!store.user && localStorage.getItem('CHALLENGE-TOKEN')) {
+      store.setUser({
+        _id: authData.me?._id || '000',
+        email: authData.me?.email || '',
+        name: authData.me?.name || '',
+      });
+    }
+  }, []);
 
   return (
     <Container maxW={'7xl'}>


### PR DESCRIPTION
# In this PR
- Started to persist user information on refresh, since when the user refreshes the page mannualy it would clear the local state, and so losing the logged user information
- Added a button on each product that lets you access the external reference link for it, if exists. And also a warning modal before actually redirecting the user to the external website.